### PR TITLE
fix: build a docker image only when pr is merged and direct push to master branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - master
+    types: 
+      - closed
   push:
     branches: 
       - master
@@ -29,5 +31,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: run build script
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event.pull_request.merged == true }}
         run: ./my_build.sh
 


### PR DESCRIPTION
build a docker image only when pr is merged and direct push to master branch